### PR TITLE
ADATA-54: Endret footer-link "Personvern" til "Personvern og informasjonskapsler".

### DIFF
--- a/ckanext/tolltheme/public/style.css
+++ b/ckanext/tolltheme/public/style.css
@@ -138,7 +138,7 @@ footer {
 .footer-links {
   display: grid;
   justify-content: center;
-  grid-column-gap: 5%;
+  grid-column-gap: 6%;
   grid-row-gap: 10%;
   margin-bottom: 3em;
 }
@@ -149,10 +149,10 @@ footer {
   }
 }
 
-@media (min-width: 580px) {
+@media (min-width: 992px) {
   .footer-links {
     grid-template-columns: auto auto auto auto;
-    grid-column-gap: 10%;
+    grid-column-gap: 11%;
   }
 }
 

--- a/ckanext/tolltheme/templates/footer.html
+++ b/ckanext/tolltheme/templates/footer.html
@@ -1,17 +1,21 @@
 <footer>
   {% block footer %}
-    <div class="footer-links">
-      <a href="https://www.toll.no/no/om-tolletaten/om-oss/">Om Tolletaten</a>
-      <a href="https://www.toll.no/no/om-tolletaten/personvern/personvern-pa-tollno/">Personvern</a>
-      <a href="https://docs.ckan.org/en/2.8/api/">CKAN API</a>
-      <a href="https://ckan.org/">CKAN Association</a>
-    </div>
-    <div class="toll-footer">
-      <p>
-        <a href="https://www.toll.no">Tolletaten</a>
-        <span> | Besokadresse: Tollbugata 1, 0152 Oslo | Postadresse: Postboks 2103 Vika, 0125 OSLO | Org.nr. 974761343 | </span>
-        <a href="https://www.toll.no/no/om-tolletaten/kontakt-oss/">Kontakt Tolletaten</a>
-      </p>
+    <div class="container">
+      <div class="footer-links">
+        <a href="https://www.toll.no/no/om-tolletaten/om-oss/">Om Tolletaten</a>
+        <a href="https://www.toll.no/no/om-tolletaten/personvern/personvern-pa-tollno/">
+          Personvern og informasjonskapsler
+        </a>
+        <a href="https://docs.ckan.org/en/2.8/api/">CKAN API</a>
+        <a href="https://ckan.org/">CKAN Association</a>
+      </div>
+      <div class="toll-footer">
+        <p>
+          <a href="https://www.toll.no">Tolletaten</a>
+          <span> | Besokadresse: Tollbugata 1, 0152 Oslo | Postadresse: Postboks 2103 Vika, 0125 OSLO | Org.nr. 974761343 | </span>
+          <a href="https://www.toll.no/no/om-tolletaten/kontakt-oss/">Kontakt Tolletaten</a>
+        </p>
+      </div>
     </div>
   {% endblock %}
 


### PR DESCRIPTION
Endret visningstekst for link og justert hvordan footer oppfører seg på
små skjermer, for å håndtere ny lenge på link-blokken.
@tormagnehougen